### PR TITLE
[SMALLFIX] Lack of env var CIRCLECI should not forbid running experiments

### DIFF
--- a/rllab/config.py
+++ b/rllab/config.py
@@ -77,7 +77,4 @@ else:
     from .config_personal import *
     print("Personal config created, but you should probably edit it before further experiments " \
           "are run")
-    if 'CIRCLECI' not in os.environ:
-        print("Exiting.")
-        import sys; sys.exit(0)
 


### PR DESCRIPTION
After installing anaconda and running ./scripts/setup_osx.sh, `python examples/ddpg_cartpole_stub.py` fails with
```
...
Personal config created, but you should probably edit it before further experiments are run
Exiting.
```

This is because of the code deleted in this PR. I don't think running an experiment needs to set env vars for an integration system, the `if` block should be deleted.

Currently, I work around this problem by exporting `CIRCLECI` to be an arbitrary non-empty string.