### PR TITLE
[SMALLFIX] Make it able to continuously run policy simulation

### DIFF
--- a/rllab/sampler/utils.py
+++ b/rllab/sampler/utils.py
@@ -31,7 +31,7 @@ def rollout(env, agent, max_path_length=np.inf, animated=False, speedup=1):
             timestep = 0.05
             time.sleep(timestep / speedup)
     if animated:
-        env.render(close=True)
+        return
 
     return dict(
         observations=tensor_utils.stack_tensor_list(observations),

--- a/scripts/sim_policy.py
+++ b/scripts/sim_policy.py
@@ -1,3 +1,4 @@
+from rllab.misc.console import query_yes_no
 from rllab.sampler.utils import rollout
 import argparse
 import joblib
@@ -27,11 +28,12 @@ if __name__ == "__main__":
     # import tensorflow as tf
     # with tf.Session():
     #     [rest of the code]
-    while True:
-        with tf.Session() as sess:
-            data = joblib.load(args.file)
-            policy = data['policy']
-            env = data['env']
-            while True:
-                path = rollout(env, policy, max_path_length=args.max_path_length,
-                               animated=True, speedup=args.speedup)
+    with tf.Session() as sess:
+        data = joblib.load(args.file)
+        policy = data['policy']
+        env = data['env']
+        while True:
+            path = rollout(env, policy, max_path_length=args.max_path_length,
+                           animated=True, speedup=args.speedup)
+            if not query_yes_no('Continue simulation?'):
+                break

--- a/scripts/sim_policy.py
+++ b/scripts/sim_policy.py
@@ -1,14 +1,10 @@
-from rllab.misc.console import query_yes_no
-from rllab.sampler.utils import rollout
 import argparse
+
 import joblib
-import uuid
-import os
-import random
-import numpy as np
 import tensorflow as tf
 
-filename = str(uuid.uuid4())
+from rllab.misc.console import query_yes_no
+from rllab.sampler.utils import rollout
 
 if __name__ == "__main__":
 
@@ -20,9 +16,6 @@ if __name__ == "__main__":
     parser.add_argument('--speedup', type=float, default=1,
                         help='Speedup')
     args = parser.parse_args()
-
-    policy = None
-    env = None
 
     # If the snapshot file use tensorflow, do:
     # import tensorflow as tf


### PR DESCRIPTION
After running `python examples/ddpg_cartpole_stub.py`, I tried to simulate the learned policy via `python scripts/sim_policy.py <path to params.pkl>`, I got the following error:
```
raceback (most recent call last):
  File "scripts/sim_policy.py", line 37, in <module>
    animated=True, speedup=args.speedup)
  File "/Users/changcheng/code/openai/rllab/rllab/sampler/utils.py", line 34, in rollout
    env.render(close=True)
  File "/Users/changcheng/code/openai/rllab/rllab/envs/proxy_env.py", line 27, in render
    return self._wrapped_env.render(*args, **kwargs)
TypeError: render() got an unexpected keyword argument 'close'
```
After getting this error, the animation window closes automatically. 

To be more user-friendly, changes in this PR makes it able to terminate or continue simulation after each rollout.