### PR TITLE
Add default get_param_values and set_param_values

### DIFF
--- a/rllab/envs/base.py
+++ b/rllab/envs/base.py
@@ -80,6 +80,12 @@ class Env(object):
         """
         pass
 
+    def get_param_values(self):
+        return None
+
+    def set_param_values(self, params):
+        pass
+
 
 _Step = collections.namedtuple("Step", ["observation", "reward", "done", "info"])
 

--- a/sandbox/rocky/tf/samplers/batch_sampler.py
+++ b/sandbox/rocky/tf/samplers/batch_sampler.py
@@ -26,10 +26,7 @@ class BatchSampler(BaseSampler):
 
     def obtain_samples(self, itr):
         cur_policy_params = self.algo.policy.get_param_values()
-        if hasattr(self.algo.env,"get_param_values"):
-            cur_env_params = self.algo.env.get_param_values()
-        else:
-            cur_env_params = None
+        cur_env_params = self.algo.env.get_param_values()
         paths = parallel_sampler.sample_paths(
             policy_params=cur_policy_params,
             env_params=cur_env_params,


### PR DESCRIPTION
Now we can assume that environment has get_param_values.

ProxyEnv assumes that the wrapped env has these functions available, so right now, the code breaks if you try to (e.g.) run
```
env = normalize(CartpoleEnv())
```
and try to use `BatchSampler` on env. The line that says
```
if hasattr(self.algo.env,"get_param_values"):
```
will be True, but the `ProxyEnv` code will fail when it calls
```
def get_param_values(self):
    return self._wrapped_env.get_param_values()
```
since CartpoleEnv doesn't have a `get_param_values` method.