### PR TITLE
Add option to always return the paths even if animated is True.

### DIFF
--- a/rllab/sampler/utils.py
+++ b/rllab/sampler/utils.py
@@ -3,7 +3,8 @@ from rllab.misc import tensor_utils
 import time
 
 
-def rollout(env, agent, max_path_length=np.inf, animated=False, speedup=1):
+def rollout(env, agent, max_path_length=np.inf, animated=False, speedup=1,
+            always_return_paths=False):
     observations = []
     actions = []
     rewards = []
@@ -30,7 +31,7 @@ def rollout(env, agent, max_path_length=np.inf, animated=False, speedup=1):
             env.render()
             timestep = 0.05
             time.sleep(timestep / speedup)
-    if animated:
+    if animated and not always_return_paths:
         return
 
     return dict(


### PR DESCRIPTION
This option is useful when debugging if I want to both render the environment and look at the data in the path. Shouldn't affect behavior for other uses.