### PR TITLE
Cache env spec and space

### DIFF
--- a/rllab/envs/base.py
+++ b/rllab/envs/base.py
@@ -1,5 +1,6 @@
 from .env_spec import EnvSpec
 import collections
+from cached_property import cached_property
 
 
 class Env(object):
@@ -59,7 +60,7 @@ class Env(object):
         """
         pass
 
-    @property
+    @cached_property
     def spec(self):
         return EnvSpec(
             observation_space=self.observation_space,

--- a/rllab/envs/mujoco/mujoco_env.py
+++ b/rllab/envs/mujoco/mujoco_env.py
@@ -1,5 +1,6 @@
 import numpy as np
 import os.path as osp
+from cached_property import cached_property
 
 from rllab import spaces
 from rllab.envs.base import Env
@@ -86,7 +87,7 @@ class MujocoEnv(Env):
         self.reset()
         super(MujocoEnv, self).__init__()
 
-    @property
+    @cached_property
     @overrides
     def action_space(self):
         bounds = self.model.actuator_ctrlrange
@@ -94,7 +95,7 @@ class MujocoEnv(Env):
         ub = bounds[:, 1]
         return spaces.Box(lb, ub)
 
-    @property
+    @cached_property
     @overrides
     def observation_space(self):
         shp = self.get_current_obs().shape


### PR DESCRIPTION
The `env_spec`, `action_space`, and `observation_space` methods might get called a lot e.g. to flatten and unflatten data. Making the cached_properties can speed things up. I was profiling my coding and noticed that these calls were taking a non-trivial amount of time.