### PR TITLE
Splitting trpo_gym examples into two different examples using differe…

### DIFF
--- a/examples/trpo_gym_cartpole.py
+++ b/examples/trpo_gym_cartpole.py
@@ -3,13 +3,17 @@ from rllab.baselines.linear_feature_baseline import LinearFeatureBaseline
 from rllab.envs.gym_env import GymEnv
 from rllab.envs.normalized_env import normalize
 from rllab.misc.instrument import run_experiment_lite
-from rllab.policies.gaussian_mlp_policy import GaussianMLPPolicy
+from rllab.policies.categorical_mlp_policy import CategoricalMLPPolicy
 
 
 def run_task(*_):
-    env = normalize(GymEnv("Pendulum-v0"))
+    # Please note that different environments with different action spaces may
+    # require different policies. For example with a Discrete action space, a
+    # CategoricalMLPPolicy works, but for a Box action space may need to use
+    # a GaussianMLPPolicy (see the trpo_gym_pendulum.py example)
+    env = normalize(GymEnv("CartPole-v0"))
 
-    policy = GaussianMLPPolicy(
+    policy = CategoricalMLPPolicy(
         env_spec=env.spec,
         # The neural network policy should have two hidden layers, each with 32 hidden units.
         hidden_sizes=(8, 8)

--- a/examples/trpo_gym_pendulum.py
+++ b/examples/trpo_gym_pendulum.py
@@ -1,0 +1,48 @@
+from rllab.algos.trpo import TRPO
+from rllab.baselines.linear_feature_baseline import LinearFeatureBaseline
+from rllab.envs.gym_env import GymEnv
+from rllab.envs.normalized_env import normalize
+from rllab.misc.instrument import run_experiment_lite
+from rllab.policies.gaussian_mlp_policy import GaussianMLPPolicy
+
+
+def run_task(*_):
+    # Please note that different environments with different action spaces may require different
+    # policies. For example with a Box action space, a GaussianMLPPolicy works, but for a Discrete
+    # action space may need to use a CategoricalMLPPolicy (see the trpo_gym_cartpole.py example)
+    env = normalize(GymEnv("Pendulum-v0"))
+
+    policy = GaussianMLPPolicy(
+        env_spec=env.spec,
+        # The neural network policy should have two hidden layers, each with 32 hidden units.
+        hidden_sizes=(8, 8)
+    )
+
+    baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+    algo = TRPO(
+        env=env,
+        policy=policy,
+        baseline=baseline,
+        batch_size=4000,
+        max_path_length=env.horizon,
+        n_itr=50,
+        discount=0.99,
+        step_size=0.01,
+        # Uncomment both lines (this and the plot parameter below) to enable plotting
+        # plot=True,
+    )
+    algo.train()
+
+
+run_experiment_lite(
+    run_task,
+    # Number of parallel workers for sampling
+    n_parallel=1,
+    # Only keep the snapshot parameters for the last iteration
+    snapshot_mode="last",
+    # Specifies the seed for the experiment. If this is not provided, a random seed
+    # will be used
+    seed=1,
+    # plot=True,
+)

--- a/examples/trpo_gym_tf_cartpole.py
+++ b/examples/trpo_gym_tf_cartpole.py
@@ -1,0 +1,42 @@
+from rllab.baselines.linear_feature_baseline import LinearFeatureBaseline
+from rllab.envs.gym_env import GymEnv
+from rllab.envs.normalized_env import normalize
+from rllab.misc.instrument import stub, run_experiment_lite
+
+from sandbox.rocky.tf.envs.base import TfEnv
+from sandbox.rocky.tf.policies.categorical_mlp_policy import CategoricalMLPPolicy
+from sandbox.rocky.tf.algos.trpo import TRPO
+
+stub(globals())
+
+# Need to wrap in a tf environment and force_reset to true
+# see https://github.com/openai/rllab/issues/87#issuecomment-282519288
+env = TfEnv(normalize(GymEnv("CartPole-v0", force_reset=True)))
+
+policy = CategoricalMLPPolicy(
+name="policy",
+env_spec=env.spec,
+# The neural network policy should have two hidden layers, each with 32 hidden units.
+hidden_sizes=(32, 32)
+)
+
+baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+algo = TRPO(
+    env=env,
+    policy=policy,
+    baseline=baseline,
+    batch_size=4000,
+    max_path_length=200,
+    n_itr=120,
+    discount=0.99,
+    step_size=0.01,
+    # optimizer=ConjugateGradientOptimizer(hvp_approach=FiniteDifferenceHvp(base_eps=1e-5))
+)
+
+run_experiment_lite(
+    algo.train(),
+    n_parallel=1,
+    snapshot_mode="last",
+    seed=1
+)


### PR DESCRIPTION
…nt policies.

For beginners using rllab it is unclear why an exception is thrown for the trpo_gym
example. It seems as though it should work as is. By splitting it up, we are help
guide beginners in understanding why different policies are needed and which ones
can be used for which environments.

See: https://github.com/openai/rllab/issues/64
