### PR TITLE
Fix the url to tlatorre

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: rllab3
 channels:
     - https://conda.anaconda.org/kne 
-    - https://conda.binstar.org/tlatorre 
+    - https://conda.anaconda.org/tlatorre 
     - https://conda.anaconda.org/cjs14
     - https://conda.anaconda.org/menpo
     - jjhelmus


### PR DESCRIPTION
Change https://conda.binstar.org/tlatorre to https://conda.anaconda.org/tlatorre