### PR TITLE
Add ability to zip up an arbitrary amount of code folders when sendin…

### DIFF
--- a/rllab/misc/instrument.py
+++ b/rllab/misc/instrument.py
@@ -1052,13 +1052,14 @@ def s3_sync_code(config, dry=False, added_project_directories=[]):
 
         tar_cmd = ["tar", "-zcvf", file_path, "-C", config.PROJECT_PATH]
 
-        for path in added_project_directories:
-            tar_cmd.append("-C")
-            tar_cmd.append(path)
-
         for pattern in config.FAST_CODE_SYNC_IGNORES:
             tar_cmd += ["--exclude", pattern]
         tar_cmd += ["-h", "."]
+
+        for path in added_project_directories:
+            tar_cmd.append("-C")
+            tar_cmd.append(path)
+            tar_cmd += ["."]
 
         remote_path = "%s/%s" % (base, file_name)
 

--- a/rllab/misc/instrument.py
+++ b/rllab/misc/instrument.py
@@ -361,6 +361,7 @@ def run_experiment_lite(
         sync_all_data_node_to_s3=True,
         use_cloudpickle=None,
         pre_commands=None,
+        added_project_directories=[],
         **kwargs):
     """
     Serialize the stubbed method call and run the experiment using the specified mode.
@@ -527,7 +528,7 @@ def run_experiment_lite(
     elif mode == "ec2":
         if docker_image is None:
             docker_image = config.DOCKER_IMAGE
-        s3_code_path = s3_sync_code(config, dry=dry)
+        s3_code_path = s3_sync_code(config, dry=dry, added_project_directories=added_project_directories)
         launch_ec2(batch_tasks,
                    exp_prefix=exp_prefix,
                    docker_image=docker_image,
@@ -818,6 +819,7 @@ def launch_ec2(params_list, exp_prefix, docker_image, code_full_path,
         sio.write("""
             aws s3 cp --recursive {code_full_path} {local_code_path}
         """.format(code_full_path=code_full_path, local_code_path=config.DOCKER_CODE_DIR))
+
     s3_mujoco_key_path = config.AWS_CODE_SYNC_S3_PATH + '/.mujoco/'
     # sio.write("""
     #     aws s3 cp --recursive {} {} --region {}
@@ -1027,7 +1029,7 @@ def launch_ec2(params_list, exp_prefix, docker_image, code_full_path,
 S3_CODE_PATH = None
 
 
-def s3_sync_code(config, dry=False):
+def s3_sync_code(config, dry=False, added_project_directories=[]):
     global S3_CODE_PATH
     if S3_CODE_PATH is not None:
         return S3_CODE_PATH
@@ -1049,6 +1051,11 @@ def s3_sync_code(config, dry=False):
         file_path = "/tmp/" + file_name
 
         tar_cmd = ["tar", "-zcvf", file_path, "-C", config.PROJECT_PATH]
+
+        for path in added_project_directories:
+            tar_cmd.append("-C")
+            tar_cmd.append(path)
+
         for pattern in config.FAST_CODE_SYNC_IGNORES:
             tar_cmd += ["--exclude", pattern]
         tar_cmd += ["-h", "."]
@@ -1354,7 +1361,6 @@ def concretize(maybe_stub):
                 print(("Error while instantiating %s" % maybe_stub.proxy_class))
                 import traceback
                 traceback.print_exc()
-                # import ipdb; ipdb.set_trace()
         ret = maybe_stub.__stub_cache
         return ret
     elif isinstance(maybe_stub, dict):


### PR DESCRIPTION
…g to ec2 instances.

This is the beginning of some changes so that we can package rllab as a library which
can be used externally. Now, you can have an arbitrary repository with your own
algorithms and can run something like:

run_experiment_lite(
    algo.train(),
    log_dir=None if args.use_ec2 else args.data_dir,
    # Number of parallel workers for sampling
    n_parallel=1,
    # Only keep the snapshot parameters for the last iteration
    snapshot_mode="last",
    # Specifies the seed for the experiment. If this is not provided, a random seed
    # will be used
    exp_prefix="myexperiments",
    seed=1,
    mode="ec2" if args.use_ec2 else "local",
    plot=False,
    # dry=True,
    added_project_directories=[osp.abspath(osp.join(osp.dirname(__file__), '.'))]
)

This will include your current project directory and send it to EC2 as if it's in the root dir of rllab.
Hence you can include your own libraries and run them without working in the rllab repo.