### PR TITLE
Added zlib dependency required by atari-py

### DIFF
--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -9,7 +9,7 @@ hash conda 2>/dev/null || {
 echo "Installing system dependencies"
 echo "You will probably be asked for your sudo password."
 sudo apt-get update
-sudo apt-get install -y python-pip python-dev swig cmake build-essential
+sudo apt-get install -y python-pip python-dev swig cmake build-essential zlib1g-dev
 sudo apt-get build-dep -y python-pygame
 sudo apt-get build-dep -y python-scipy
 


### PR DESCRIPTION
As stated in issue #151 zlib is required by atari-py but is missing in the initial packages install.