### PR TITLE
Fix bug with positional arguments in Serializable.

### DIFF
--- a/rllab/core/serializable.py
+++ b/rllab/core/serializable.py
@@ -37,20 +37,29 @@ class Serializable(object):
         return {"__args": self.__args, "__kwargs": self.__kwargs}
 
     def __setstate__(self, d):
-        # convert all __args to keyword-based arguments
-        if sys.version_info >= (3, 0):
-            spec = inspect.getfullargspec(self.__init__)
-        else:
-            spec = inspect.getargspec(self.__init__)
-        in_order_args = spec.args[1:]
-        out = type(self)(**dict(zip(in_order_args, d["__args"]), **d["__kwargs"]))
+        out = type(self)(*d["__args"], **d["__kwargs"])
         self.__dict__.update(out.__dict__)
 
     @classmethod
     def clone(cls, obj, **kwargs):
         assert isinstance(obj, Serializable)
         d = obj.__getstate__()
-        d["__kwargs"] = dict(d["__kwargs"], **kwargs)
+
+        # Split the entries in kwargs between positional and keyword arguments
+        # and update d['__args'] and d['__kwargs'], respectively.
+        if sys.version_info >= (3, 0):
+            spec = inspect.getfullargspec(obj.__init__)
+        else:
+            spec = inspect.getargspec(obj.__init__)
+        in_order_args = spec.args[1:]
+
+        d["__args"] = list(d["__args"])
+        for kw, val in kwargs.items():
+            if kw in in_order_args:
+                d["__args"][in_order_args.index(kw)] = val
+            else:
+                d["__kwargs"][kw] = val
+
         out = type(obj).__new__(type(obj))
         out.__setstate__(d)
         return out

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -14,12 +14,26 @@ class Simple(Parameterized, Serializable):
         return [self.w]
 
 
+class AllArgs(Serializable):
+    def __init__(self, vararg, *args, **kwargs):
+        Serializable.quick_init(self, locals())
+        self.vararg = vararg
+        self.args = args
+        self.kwargs = kwargs
+
+
 def test_serializable():
     with suppress_params_loading():
         obj = Simple(name="obj")
         obj1 = Serializable.clone(obj, name="obj1")
         assert obj.w.name.startswith('obj/')
         assert obj1.w.name.startswith('obj1/')
+
+        obj2 = AllArgs(0, *(1,), **{'kwarg': 2})
+        obj3 = Serializable.clone(obj2)
+        assert obj3.vararg == 0
+        assert len(obj3.args) == 1 and obj3.args[0] == 1
+        assert len(obj3.kwargs) == 1 and obj3.kwargs['kwarg'] == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixed a bug that makes serialization fail if __init__ takes an keywordless argument list (*args).