### PR TITLE
Removing mujoco_py from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,6 @@ dependencies:
         - pyzmq
         - tqdm
         - msgpack-python
-        - mujoco_py
         - cached_property
         - line_profiler
         - cloudpickle

--- a/scripts/setup_mujoco.sh
+++ b/scripts/setup_mujoco.sh
@@ -14,7 +14,7 @@ fi
 
 if [ ! -f vendor/mujoco/$mujoco_file ]; then
     read -e -p "Please enter the path to the mujoco zip file [$zip_file]:" path
-    path=${path:-$zip_file} 
+    path=${path:-$zip_file}
     eval path=\"$path\"
     if [ ! -f $path ]; then
         echo "No file found at $path"
@@ -48,4 +48,9 @@ if [ ! -f vendor/mujoco/mjkey.txt ]; then
     cp $path vendor/mujoco/mjkey.txt
 fi
 
+if [ "$(conda info --envs | grep -c rllab3)" -eq "1" ]; then
+    /bin/bash -c "source activate rllab3; pip install mujoco_py; source deactivate"
+else
+    echo "Installation of mujoco_py skipped, since the conda environment rllab3 was not found."
+fi
 echo "Mujoco has been set up!"


### PR DESCRIPTION
Following #162, removed mujoco_py from environment.yml, and moved its installation to scripts/setup_mujoco.py, by checking whether the conda environment rllab3 exists, and if so sourcing into rllab3 and running `pip install mujoco_py` within it.